### PR TITLE
Add Marshal Support for More Types

### DIFF
--- a/message.go
+++ b/message.go
@@ -767,7 +767,10 @@ func (m *Message) marshal(v interface{}) error {
 func (m *Message) marshalField(name string, rv reflect.Value) error {
 	switch rv.Kind() {
 
-	case reflect.String, reflect.Slice, reflect.Array:
+	case reflect.String:
+		return m.addItem(name, rv.String())
+
+	case reflect.Slice, reflect.Array:
 		return m.addItem(name, rv.Interface())
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -849,7 +852,7 @@ func (m *Message) unmarshalField(field reflect.Value, rv reflect.Value) error {
 		if _, ok := rv.Interface().(string); !ok {
 			return fmt.Errorf("%v: string and %v", errUnmarshalTypeMismatch, rv.Type())
 		}
-		field.Set(rv)
+		field.SetString(rv.String())
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		raw, ok := rv.Interface().(string)

--- a/message_marshal_test.go
+++ b/message_marshal_test.go
@@ -35,7 +35,7 @@ func TestMarshalBoolTrue(t *testing.T) {
 
 	m, err := MarshalMessage(boolMessage)
 	if err != nil {
-		t.Errorf("Error marshalling bool value: %v", err)
+		t.Fatalf("Error marshalling bool value: %v", err)
 	}
 
 	value := m.Get("field")
@@ -55,7 +55,7 @@ func TestMarshalBoolFalse(t *testing.T) {
 
 	m, err := MarshalMessage(boolMessage)
 	if err != nil {
-		t.Errorf("Error marshalling bool value: %v", err)
+		t.Fatalf("Error marshalling bool value: %v", err)
 	}
 
 	value := m.Get("field")
@@ -63,4 +63,99 @@ func TestMarshalBoolFalse(t *testing.T) {
 		t.Errorf("Marshalled boolean value is invalid.\nExpected: no\nReceived: %+v", value)
 	}
 
+}
+
+func TestMarshalInt(t *testing.T) {
+
+	intMessage := struct {
+		Field int `vici:"field"`
+	}{
+		Field: 23,
+	}
+
+	m, err := MarshalMessage(intMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling int value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "23") {
+		t.Errorf("Marshalled int value is invalid.\nExpected: 23\nReceived: %+v", value)
+	}
+}
+
+func TestMarshalInt2(t *testing.T) {
+
+	intMessage := struct {
+		Field int `vici:"field"`
+	}{
+		Field: -23,
+	}
+
+	m, err := MarshalMessage(intMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling int value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "-23") {
+		t.Errorf("Marshalled int value is invalid.\nExpected: -23\nReceived: %+v", value)
+	}
+}
+
+func TestMarshalInt8(t *testing.T) {
+
+	intMessage := struct {
+		Field int8 `vici:"field"`
+	}{
+		Field: 23,
+	}
+
+	m, err := MarshalMessage(intMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling int8 value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "23") {
+		t.Errorf("Marshalled int8 value is invalid.\nExpected: 23\nReceived: %+v", value)
+	}
+}
+
+func TestMarshalUint(t *testing.T) {
+
+	intMessage := struct {
+		Field uint `vici:"field"`
+	}{
+		Field: 23,
+	}
+
+	m, err := MarshalMessage(intMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling uint value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "23") {
+		t.Errorf("Marshalled uint value is invalid.\nExpected: 23\nReceived: %+v", value)
+	}
+}
+
+func TestMarshalUint8(t *testing.T) {
+
+	intMessage := struct {
+		Field uint8 `vici:"field"`
+	}{
+		Field: 23,
+	}
+
+	m, err := MarshalMessage(intMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling uint8 value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "23") {
+		t.Errorf("Marshalled uint8 value is invalid.\nExpected: 23\nReceived: %+v", value)
+	}
 }

--- a/message_marshal_test.go
+++ b/message_marshal_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2019 Arroyo Networks, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package vici
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMarshalBoolTrue(t *testing.T) {
+
+	boolMessage := struct {
+		Field bool `vici:"field"`
+	}{
+		Field: true,
+	}
+
+	m, err := MarshalMessage(boolMessage)
+	if err != nil {
+		t.Errorf("Error marshalling bool value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "yes") {
+		t.Errorf("Marshalled boolean value is invalid.\nExpected: yes\nReceived: %+v", value)
+	}
+
+}
+
+func TestMarshalBoolFalse(t *testing.T) {
+
+	boolMessage := struct {
+		Field bool `vici:"field"`
+	}{
+		Field: false,
+	}
+
+	m, err := MarshalMessage(boolMessage)
+	if err != nil {
+		t.Errorf("Error marshalling bool value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "no") {
+		t.Errorf("Marshalled boolean value is invalid.\nExpected: no\nReceived: %+v", value)
+	}
+
+}

--- a/message_marshal_test.go
+++ b/message_marshal_test.go
@@ -159,3 +159,26 @@ func TestMarshalUint8(t *testing.T) {
 		t.Errorf("Marshalled uint8 value is invalid.\nExpected: 23\nReceived: %+v", value)
 	}
 }
+
+func TestMarshalEnumType(t *testing.T) {
+
+	type TestType string
+	const testValue TestType = "test-value"
+
+	enumMessage := struct {
+		Field TestType `vici:"field"`
+	}{
+		Field: testValue,
+	}
+
+	m, err := MarshalMessage(enumMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling enum type value: %v", err)
+	}
+
+	value := m.Get("field")
+	if value.(string) != string(testValue) {
+		t.Errorf("Marshalled enum type value is invalid.\nExpected: %+v\nReceived: %+v", testValue, value)
+	}
+
+}

--- a/message_unmarshal_test.go
+++ b/message_unmarshal_test.go
@@ -41,7 +41,7 @@ func TestUnmarshalBoolTrue(t *testing.T) {
 
 	err := UnmarshalMessage(m, &boolMessage)
 	if err != nil {
-		t.Errorf("Error unmarshalling bool value: %v", err)
+		t.Fatalf("Error unmarshalling bool value: %v", err)
 	}
 
 	if boolMessage.Field != true {
@@ -66,7 +66,7 @@ func TestUnmarshalBoolFalse(t *testing.T) {
 
 	err := UnmarshalMessage(m, &boolMessage)
 	if err != nil {
-		t.Errorf("Error unmarshalling bool value: %v", err)
+		t.Fatalf("Error unmarshalling bool value: %v", err)
 	}
 
 	if boolMessage.Field != false {
@@ -92,5 +92,151 @@ func TestUnmarshalBoolInvalid(t *testing.T) {
 	err := UnmarshalMessage(m, &boolMessage)
 	if err == nil {
 		t.Error("Expected error when unmarshalling invalid boolean value. None was returned.")
+	}
+}
+
+func TestUnmarshalInt(t *testing.T) {
+
+	intMessage := struct {
+		Field int `vici:"field"`
+	}{
+		Field: 0,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "23",
+		},
+	}
+
+	err := UnmarshalMessage(m, &intMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling int value: %v", err)
+	}
+
+	if intMessage.Field != 23 {
+		t.Errorf("Unmarshalled int value is invalid.\nExpected: 23\nReceived: %+v", intMessage.Field)
+	}
+}
+
+func TestUnmarshalInt2(t *testing.T) {
+
+	intMessage := struct {
+		Field int `vici:"field"`
+	}{
+		Field: 0,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "-23",
+		},
+	}
+
+	err := UnmarshalMessage(m, &intMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling int value: %v", err)
+	}
+
+	if intMessage.Field != -23 {
+		t.Errorf("Unmarshalled int value is invalid.\nExpected: -23\nReceived: %+v", intMessage.Field)
+	}
+}
+
+func TestUnmarshalInt8(t *testing.T) {
+
+	intMessage := struct {
+		Field int8 `vici:"field"`
+	}{
+		Field: 0,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "23",
+		},
+	}
+
+	err := UnmarshalMessage(m, &intMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling int8 value: %v", err)
+	}
+
+	if intMessage.Field != 23 {
+		t.Errorf("Unmarshalled int8 value is invalid.\nExpected: 23\nReceived: %+v", intMessage.Field)
+	}
+}
+
+func TestUnmarshalInt8Overflow(t *testing.T) {
+
+	intMessage := struct {
+		Field int8 `vici:"field"`
+	}{
+		Field: 0,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "1001",
+		},
+	}
+
+	err := UnmarshalMessage(m, &intMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling int8 value: %v", err)
+	}
+
+	if intMessage.Field == 23 {
+		t.Errorf("Unmarshalled int8 value is invalid.\nExpected: -23 (Overflow)\nReceived: %+v", intMessage.Field)
+	}
+}
+
+func TestUnmarshalUint(t *testing.T) {
+
+	intMessage := struct {
+		Field uint `vici:"field"`
+	}{
+		Field: 0,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "23",
+		},
+	}
+
+	err := UnmarshalMessage(m, &intMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling uint value: %v", err)
+	}
+
+	if intMessage.Field != 23 {
+		t.Errorf("Unmarshalled uint value is invalid.\nExpected: 23\nReceived: %+v", intMessage.Field)
+	}
+}
+
+func TestUnmarshalUintInvalid(t *testing.T) {
+
+	intMessage := struct {
+		Field uint `vici:"field"`
+	}{
+		Field: 0,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "-1",
+		},
+	}
+
+	err := UnmarshalMessage(m, &intMessage)
+	if err == nil {
+		t.Error("Expected error when unmarshalling invalid uint value. None was returned.")
 	}
 }

--- a/message_unmarshal_test.go
+++ b/message_unmarshal_test.go
@@ -1,0 +1,96 @@
+// Copyright (C) 2019 Arroyo Networks, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package vici
+
+import (
+	"testing"
+)
+
+func TestUnmarshalBoolTrue(t *testing.T) {
+
+	boolMessage := struct {
+		Field bool `vici:"field"`
+	}{
+		Field: false,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "yes",
+		},
+	}
+
+	err := UnmarshalMessage(m, &boolMessage)
+	if err != nil {
+		t.Errorf("Error unmarshalling bool value: %v", err)
+	}
+
+	if boolMessage.Field != true {
+		t.Errorf("Unmarshalled boolean value is invalid.\nExpected: true\nReceived: %+v", boolMessage.Field)
+	}
+}
+
+func TestUnmarshalBoolFalse(t *testing.T) {
+
+	boolMessage := struct {
+		Field bool `vici:"field"`
+	}{
+		Field: true,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "no",
+		},
+	}
+
+	err := UnmarshalMessage(m, &boolMessage)
+	if err != nil {
+		t.Errorf("Error unmarshalling bool value: %v", err)
+	}
+
+	if boolMessage.Field != false {
+		t.Errorf("Unmarshalled boolean value is invalid.\nExpected: false\nReceived: %+v", boolMessage.Field)
+	}
+}
+
+func TestUnmarshalBoolInvalid(t *testing.T) {
+
+	boolMessage := struct {
+		Field bool `vici:"field"`
+	}{
+		Field: true,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "invalid-not-a-bool",
+		},
+	}
+
+	err := UnmarshalMessage(m, &boolMessage)
+	if err == nil {
+		t.Error("Expected error when unmarshalling invalid boolean value. None was returned.")
+	}
+}

--- a/message_unmarshal_test.go
+++ b/message_unmarshal_test.go
@@ -240,3 +240,29 @@ func TestUnmarshalUintInvalid(t *testing.T) {
 		t.Error("Expected error when unmarshalling invalid uint value. None was returned.")
 	}
 }
+
+func TestUnmarshalEnumType(t *testing.T) {
+
+	type TestType string
+	const testValue TestType = "test-value"
+
+	enumMessage := struct {
+		Field TestType `vici:"field"`
+	}{}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "test-value",
+		},
+	}
+
+	err := UnmarshalMessage(m, &enumMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling enum type value: %v", err)
+	}
+
+	if enumMessage.Field != testValue {
+		t.Errorf("Unmarshalled uint value is invalid.\nExpected: %+v\nReceived: %+v", testValue, enumMessage.Field)
+	}
+}


### PR DESCRIPTION
Add support for marshaling additional Go types, allowing for the use of more "natural" structures when encoding Vici messages.

The following types are now supported:

- Bools (Marshalled to "yes" or "no")
- Integers
- Custom / Enum String Types (e.g. `type MyType string`)