### PR TITLE
Marshal Support for Maps

### DIFF
--- a/message_marshal_test.go
+++ b/message_marshal_test.go
@@ -182,3 +182,31 @@ func TestMarshalEnumType(t *testing.T) {
 	}
 
 }
+
+func TestMarshalEmbeddedMap(t *testing.T) {
+
+	mapValue := map[string]interface{}{"sub": goldUnmarshaled}
+
+	mapMessage := struct {
+		Field map[string]interface{} `vici:"field"`
+	}{
+		Field: mapValue,
+	}
+
+	m, err := MarshalMessage(mapMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling map value: %v", err)
+	}
+
+	value := m.Get("field")
+	field, ok := value.(*Message)
+	if !ok {
+		t.Fatalf("Embedded map key was not marshaled as a sub-message")
+	}
+
+	value = field.Get("sub")
+	if !reflect.DeepEqual(value, goldMarshaled) {
+		t.Errorf("Marshalled map value is invalid.\nExpected: %+v\nReceived: %+v", goldMarshaled, value)
+	}
+
+}


### PR DESCRIPTION
Maps can be marshaled at the top-level or embedded in structs
as exported fields.

---

This is great for dealing with many of the Vici commands where we don't know the key names ahead of time or otherwise would require manually iterating the Message keys and marshaling/unmarshaling sub-fields.

For example with `load-conn`, it allows us to quickly unmarshal into a `map[string]*OurConnStruct` without having to iterate over each key in the Message manually.

It also helps out with our message structures, for example, or IKE Config structs can include simplified Children fields:

```go
type IKEConfig struct {
	Version IKEVersion `json:"version" vici:"version"`

	Encap bool `json:"encap" vici:"encap"`

	DPDDelaySec   int `json:"dpd_delay" vici:"dpd_delay"`
	DPDTimeoutSec int `json:"dpd_timeout" vici:"dpd_timeout"`

	Pools []string `json:"pools" vici:"pools"`

	LocalAuth  []*AuthConfig `json:"local,omitempty"`
	RemoteAuth []*AuthConfig `json:"remote,omitempty"`

	Children map[string]*ChildSAConfig `json:"children" vici:"children"`
}
```