### PR TITLE
Initialize Pointer Field if Nil when Unmarshaling

### DIFF
--- a/message.go
+++ b/message.go
@@ -1028,6 +1028,10 @@ func (m *Message) unmarshalField(field reflect.Value, rv reflect.Value) error {
 			return fmt.Errorf("%v: %v", errUnmarshalNonMessage, rv.Type())
 		}
 
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+
 		return msg.unmarshal(field.Interface())
 
 	case reflect.Struct:

--- a/message_test.go
+++ b/message_test.go
@@ -316,6 +316,21 @@ func TestUnmarshalMessageToNilPointer(t *testing.T) {
 	}
 }
 
+func TestUnmarshalMessageNestedNilPtr(t *testing.T) {
+	tm := &testMessage{
+		Message: NewMessage(),
+	}
+
+	err := UnmarshalMessage(goldMarshaled, tm)
+	if err != nil {
+		t.Errorf("Unexpected error unmarshaling: %v", err)
+	}
+
+	if !reflect.DeepEqual(*tm, goldUnmarshaled) {
+		t.Errorf("Unmarshaled message does not equal gold struct.\nExpected: %+v\nReceived: %+v", goldUnmarshaled, *tm)
+	}
+}
+
 func TestMessageGet(t *testing.T) {
 	v := goldMessage.Get("key1")
 	if value, ok := v.(string); !ok {


### PR DESCRIPTION
This allows the unmarshaling of deeply nested structs and maps without having to preallocate each of their fields when using pointers.

Last one I have for now!