### PR TITLE
Change Listen API, add Session.Close

### DIFF
--- a/message.go
+++ b/message.go
@@ -161,7 +161,10 @@ func (m *Message) Get(key string) interface{} {
 
 // Keys returns the list of valid message keys.
 func (m *Message) Keys() []string {
-	return m.keys
+	keys := make([]string, len(m.keys))
+	copy(keys, m.keys)
+
+	return keys
 }
 
 // Err examines a command response Message, and determines if it was successful.

--- a/session.go
+++ b/session.go
@@ -27,7 +27,15 @@
 package vici
 
 import (
+	"context"
+	"errors"
 	"sync"
+)
+
+var (
+	// Event listener errors
+	errNoEventListener     = errors.New("vici: event listener is not active")
+	errEventListenerExists = errors.New("vici: event listener already exists")
 )
 
 // Session is a vici client session.
@@ -41,7 +49,11 @@ type Session struct {
 	mux sync.Mutex
 	ctr *transport
 
-	el *eventListener
+	// Allow many readers, i.e. NextEvent callers, to try to read from
+	// event listener. Writer lock is for creation and destruction of
+	// the event listener.
+	emux sync.RWMutex
+	el   *eventListener
 }
 
 // NewSession returns a new vici session.
@@ -50,14 +62,9 @@ func NewSession() (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	elt, err := newTransport(nil)
-	if err != nil {
-		return nil, err
-	}
 
 	s := &Session{
 		ctr: ctr,
-		el:  newEventListener(elt),
 	}
 
 	return s, nil
@@ -79,16 +86,57 @@ func (s *Session) StreamedCommandRequest(cmd string, event string, msg *Message)
 	return s.sendStreamedRequest(cmd, event, msg)
 }
 
-// Listen registers the session to listen for all events given. Listen does not return
-// unless the event channel is closed. To receive events that are registered here, use
-// NextEvent. Listen should not be called again until the previous call has returned.
-func (s *Session) Listen(events []string) error {
-	return s.el.safeListen(events)
+// Listen registers the session to listen for all events given. Listen returns when the
+// event channel is closed, or the given context is cancelled. To receive events that
+// are registered here, use NextEvent. An error is returned if Listen is called while
+// Session already has an event listener registered.
+func (s *Session) Listen(ctx context.Context, events ...string) error {
+	if err := s.maybeCreateEventListener(ctx); err != nil {
+		return err
+	}
+	defer s.destroyEventListenerWhenClosed()
+
+	return s.el.listen(events)
+}
+
+func (s *Session) maybeCreateEventListener(ctx context.Context) error {
+	s.emux.Lock()
+	defer s.emux.Unlock()
+
+	if s.el != nil {
+		return errEventListenerExists
+	}
+
+	elt, err := newTransport(nil)
+	if err != nil {
+		return err
+	}
+	s.el = newEventListener(ctx, elt)
+
+	return nil
+}
+
+func (s *Session) destroyEventListenerWhenClosed() {
+	go func() {
+		<-s.el.Done()
+
+		s.emux.Lock()
+		defer s.emux.Unlock()
+
+		s.el = nil
+	}()
 }
 
 // NextEvent returns the next event received by the session event listener.  NextEvent is a
 // blocking call. If there is no event in the event buffer, NextEvent will wait to return until
 // a new event is received. An error is returned if the event channel is closed.
 func (s *Session) NextEvent() (*Message, error) {
+	s.emux.RLock()
+	defer s.emux.RUnlock()
+
+	if s.el == nil {
+		return nil, errNoEventListener
+	}
+
 	return s.el.nextEvent()
 }

--- a/session.go
+++ b/session.go
@@ -29,6 +29,7 @@ package vici
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 )
 
@@ -104,7 +105,7 @@ func (s *Session) StreamedCommandRequest(cmd string, event string, msg *Message)
 // are registered here, use NextEvent. An error is returned if Listen is called while
 // Session already has an event listener registered.
 func (s *Session) Listen(ctx context.Context, events ...string) error {
-	if err := s.maybeCreateEventListener(ctx); err != nil {
+	if err := s.maybeCreateEventListener(ctx, nil); err != nil {
 		return err
 	}
 	defer s.destroyEventListenerWhenClosed()
@@ -112,7 +113,7 @@ func (s *Session) Listen(ctx context.Context, events ...string) error {
 	return s.el.listen(events)
 }
 
-func (s *Session) maybeCreateEventListener(ctx context.Context) error {
+func (s *Session) maybeCreateEventListener(ctx context.Context, conn net.Conn) error {
 	s.emux.Lock()
 	defer s.emux.Unlock()
 
@@ -120,7 +121,7 @@ func (s *Session) maybeCreateEventListener(ctx context.Context) error {
 		return errEventListenerExists
 	}
 
-	elt, err := newTransport(nil)
+	elt, err := newTransport(conn)
 	if err != nil {
 		return err
 	}

--- a/session.go
+++ b/session.go
@@ -70,6 +70,19 @@ func NewSession() (*Session, error) {
 	return s, nil
 }
 
+// Close closes the vici session.
+func (s *Session) Close() error {
+	if err := s.el.Close(); err != nil {
+		return err
+	}
+
+	if err := s.ctr.conn.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // CommandRequest sends a command request to the server, and returns the server's response.
 // The command is specified by cmd, and its arguments are provided by msg. An error is returned
 // if an error occurs while communicating with the daemon. To determine if a command was successful,

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,168 @@
+// Copyright (C) 2019 Nick Rosbrook
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package vici
+
+import (
+	"context"
+	"log"
+	"net"
+	"testing"
+)
+
+func mockCharon(ctx context.Context) net.Conn {
+	client, srvr := net.Pipe()
+
+	go func() {
+		defer func() {
+			srvr.Close()
+		}()
+
+		tr := &transport{conn: srvr}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				break
+			}
+
+			p, err := tr.recv()
+			if err != nil {
+				return
+			}
+
+			switch p.ptype {
+			case pktEventRegister, pktEventUnregister:
+				var ack *packet
+
+				if p.name != "test-event" {
+					ack = newPacket(pktEventUnknown, "", nil)
+				} else {
+					ack = newPacket(pktEventConfirm, "", nil)
+				}
+
+				err := tr.send(ack)
+				if err != nil {
+					return
+				}
+
+				if p.ptype == pktEventRegister {
+					// Write one event message
+					msg := NewMessage()
+					err := msg.Set("test", "hello world!")
+					if err != nil {
+						log.Printf("Failed to set message field: %v", err)
+					}
+					event := newPacket(pktEvent, "test-event", msg)
+					err = tr.send(event)
+					if err != nil {
+						log.Printf("Failed to send test-event message: %v", err)
+					}
+				}
+
+			default:
+				continue
+			}
+		}
+	}()
+
+	return client
+}
+
+// testListen used to create a listener with a net.Pipe.
+//
+// Used for testing only.
+func (s *Session) testListen(ctx context.Context, conn net.Conn, events ...string) error {
+	if err := s.maybeCreateEventListener(ctx, conn); err != nil {
+		return err
+	}
+	defer s.destroyEventListenerWhenClosed()
+
+	return s.el.listen(events)
+}
+
+func TestListenAndCancel(t *testing.T) {
+	// No need for a command transport in this test.
+	s := &Session{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dctx, dcancel := context.WithCancel(context.Background())
+	defer dcancel()
+
+	conn := mockCharon(dctx)
+
+	err := s.testListen(ctx, conn, "test-event")
+	if err != nil {
+		t.Fatalf("Failed to start event listener: %v", err)
+	}
+
+	m, err := s.NextEvent()
+	if err != nil {
+		t.Fatalf("Unexpected error on NextEvent: %v", err)
+	}
+
+	if m.Get("test") != "hello world!" {
+		t.Fatalf("Unexpected message: %v", m)
+	}
+
+	cancel()
+
+	m, err = s.NextEvent()
+	if err == nil {
+		t.Fatalf("Expected error after closing listener, got message: %v", m)
+	}
+}
+
+func TestListenAndCloseSession(t *testing.T) {
+	dctx, dcancel := context.WithCancel(context.Background())
+	defer dcancel()
+
+	conn := mockCharon(dctx)
+
+	s := &Session{
+		ctr: &transport{conn: conn},
+	}
+
+	err := s.testListen(context.Background(), conn, "test-event")
+	if err != nil {
+		t.Fatalf("Failed to start event listener: %v", err)
+	}
+
+	m, err := s.NextEvent()
+	if err != nil {
+		t.Fatalf("Unexpected error on NextEvent: %v", err)
+	}
+
+	if m.Get("test") != "hello world!" {
+		t.Fatalf("Unexpected message: %v", m)
+	}
+
+	// Close session
+	s.Close()
+
+	m, err = s.NextEvent()
+	if err == nil {
+		t.Fatalf("Expected error after closing listener, got message: %v", m)
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -96,6 +96,9 @@ func (t *transport) recv() (*packet, error) {
 
 	_, err := t.conn.Read(buf)
 	if err != nil {
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return nil, ne
+		}
 		return nil, fmt.Errorf("%v: %v", errTransport, err)
 	}
 	pl := binary.BigEndian.Uint32(buf)


### PR DESCRIPTION
* Changes to the `Session.Listen` function signature:
    Old: `func (s *Session) Listen(events []string) error`
    New: `func (s *Session) Listen(ctx context.Context, events ...string) error`
    
    This allows the event listener to be cancelled if necessary, and the variadic string arguments are more natural to use.
* `Session.Close` has been added. `Close` will close any connections, including the event listener.
 