### PR TITLE
session: check if event listener is registered before calling Close

### DIFF
--- a/session.go
+++ b/session.go
@@ -73,8 +73,11 @@ func NewSession() (*Session, error) {
 
 // Close closes the vici session.
 func (s *Session) Close() error {
-	if err := s.el.Close(); err != nil {
-		return err
+	// Check if event listener exists before closing.
+	if s.el != nil {
+		if err := s.el.Close(); err != nil {
+			return err
+		}
 	}
 
 	if err := s.ctr.conn.Close(); err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -166,3 +166,19 @@ func TestListenAndCloseSession(t *testing.T) {
 		t.Fatalf("Expected error after closing listener, got message: %v", m)
 	}
 }
+
+func TestSessionClose(t *testing.T) {
+	// Create a session without connecting to charon
+	conn, _ := net.Pipe()
+
+	s := &Session{
+		ctr: &transport{conn: conn},
+		// Event listener is not initialized,
+		// as this is done when Listen is called.
+		el: nil,
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Unpexected error when closing Session: %v", err)
+	}
+}


### PR DESCRIPTION
The recent addition of session.Close and changes to the event listener
introduced a bug. If no event listener is registered when session.Close
is called, it will panic.

This adds a check on the event listener before trying to close it, and
adds a test case for the bug.

Fixes: https://github.com/strongswan/govici/issues/6

Signed-off-by: Nick Rosbrook <rosbrookn@ainfosec.com>