### PR TITLE
message: support for pointer types other than Message

### DIFF
--- a/vici/message_marshal_test.go
+++ b/vici/message_marshal_test.go
@@ -61,6 +61,62 @@ func TestMarshalBoolFalse(t *testing.T) {
 	}
 }
 
+func TestMarshalBoolTruePtr(t *testing.T) {
+	boolValue := true
+	boolMessage := struct {
+		Field *bool `vici:"field"`
+	}{
+		Field: &boolValue,
+	}
+
+	m, err := MarshalMessage(boolMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling pointer to bool value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "yes") {
+		t.Fatalf("Marshalled boolean pointer value is invalid.\nExpected: yes\nReceived: %+v", value)
+	}
+}
+
+func TestMarshalBoolFalsePtr(t *testing.T) {
+	boolValue := false
+	boolMessage := struct {
+		Field *bool `vici:"field"`
+	}{
+		Field: &boolValue,
+	}
+
+	m, err := MarshalMessage(boolMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling pointer to bool value: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, "no") {
+		t.Fatalf("Marshalled boolean pointer value is invalid.\nExpected: no\nReceived: %+v", value)
+	}
+}
+
+func TestMarshalBoolNilPtr(t *testing.T) {
+	boolMessage := struct {
+		Field *bool `vici:"field"`
+	}{
+		Field: nil,
+	}
+
+	m, err := MarshalMessage(boolMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling pointer to bool value: %v", err)
+	}
+
+	value := m.Get("field")
+	if value != nil {
+		t.Fatalf("Marshalled nil boolean pointer value is present.\nReceived: %+v", value)
+	}
+}
+
 func TestMarshalInt(t *testing.T) {
 	intMessage := struct {
 		Field int `vici:"field"`

--- a/vici/message_unmarshal_test.go
+++ b/vici/message_unmarshal_test.go
@@ -92,6 +92,62 @@ func TestUnmarshalBoolInvalid(t *testing.T) {
 	}
 }
 
+func TestUnmarshalBoolTruePtr(t *testing.T) {
+	boolMessage := struct {
+		Field *bool `vici:"field"`
+	}{
+		Field: nil,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "yes",
+		},
+	}
+
+	err := UnmarshalMessage(m, &boolMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling bool value to pointer: %v", err)
+	}
+
+	if boolMessage.Field == nil {
+		t.Fatalf("Unmarshalled boolean pointer is nil.")
+	}
+
+	if *boolMessage.Field != true {
+		t.Fatalf("Unmarshalled boolean value is invalid.\nExpected: true\nReceived: %+v", *boolMessage.Field)
+	}
+}
+
+func TestUnmarshalBoolFalsePtr(t *testing.T) {
+	boolMessage := struct {
+		Field *bool `vici:"field"`
+	}{
+		Field: nil,
+	}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "no",
+		},
+	}
+
+	err := UnmarshalMessage(m, &boolMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling bool value to pointer: %v", err)
+	}
+
+	if boolMessage.Field == nil {
+		t.Fatalf("Unmarshalled boolean pointer is nil.")
+	}
+
+	if *boolMessage.Field != false {
+		t.Fatalf("Unmarshalled boolean value is invalid.\nExpected: false\nReceived: %+v", *boolMessage.Field)
+	}
+}
+
 func TestUnmarshalInt(t *testing.T) {
 	intMessage := struct {
 		Field int `vici:"field"`


### PR DESCRIPTION
Adds support for pointer types which are not Message.

This is especially helpful for booleans, as `*bool` can now be used to marshal conditional boolean values where there is a difference between the value being `false` and the boolean being unset.

---

These changes make it possible to differentiate between a value being explicitly set versus unset, which is important when the default StrongSwan value does not match Go's zero value.

For example, we ran into this issue when we added a configurable option for `mobike` to our app.

```go
type Config struct {
   ...
   Mobike bool `json:"mobike,omitempty" vici:"mobike"`
}
```
Since the zero value for a boolean in Go is `false`, when we added the above option to our structs, we mistakenly set all of the configs to "no" instead of keeping the StrongSwan default of "yes".

These changes allow us to use the following:

```go
type Config struct {
   ...
   Mobike *bool `json:"mobike,omitempty" vici:"mobike"`
}
```
In this case, unless we explicitly set `Mobike` to false, the default value stays "yes".

