### PR TITLE
WIP: Discussion - Expose Event Name from Packet

### DIFF
--- a/vici/events.go
+++ b/vici/events.go
@@ -58,8 +58,9 @@ type eventListener struct {
 }
 
 type event struct {
-	msg *Message
-	err error
+	name string
+	msg  *Message
+	err  error
 }
 
 func newEventListener(lctx context.Context, t *transport) *eventListener {
@@ -175,6 +176,7 @@ func (el *eventListener) listen(events []string) (err error) {
 				}
 
 				if p.ptype == pktEvent {
+					e.name = p.name
 					e.msg = p.msg
 					el.ec <- e
 				}
@@ -185,13 +187,13 @@ func (el *eventListener) listen(events []string) (err error) {
 	return nil
 }
 
-func (el *eventListener) nextEvent() (*Message, error) {
+func (el *eventListener) nextEvent() (string, *Message, error) {
 	e := <-el.ec
 	if e.msg == nil && e.err == nil {
-		return nil, errChannelClosed
+		return "", nil, errChannelClosed
 	}
 
-	return e.msg, e.err
+	return e.name, e.msg, e.err
 }
 
 func (el *eventListener) registerEvents(events []string) error {

--- a/vici/session.go
+++ b/vici/session.go
@@ -239,13 +239,26 @@ func (s *Session) maybeCreateEventListener(ctx context.Context) error {
 // NextEvent returns the next event received by the session event listener.  NextEvent is a
 // blocking call. If there is no event in the event buffer, NextEvent will wait to return until
 // a new event is received. An error is returned if the event channel is closed.
-func (s *Session) NextEvent() (*Message, error) {
+func (s *Session) NextEvent() (SessionEvent, error) {
 	s.emux.RLock()
 	defer s.emux.RUnlock()
 
 	if s.el == nil {
-		return nil, errNoEventListener
+		return SessionEvent{}, errNoEventListener
 	}
 
-	return s.el.nextEvent()
+	name, msg, err := s.el.nextEvent()
+	if err != nil {
+		return SessionEvent{}, err
+	}
+
+	return SessionEvent{
+		Name:    name,
+		Message: msg,
+	}, nil
+}
+
+type SessionEvent struct {
+	Name    string
+	Message *Message
 }


### PR DESCRIPTION
**Problem**: We listen to multiple Vici events, but currently do not have a way to easily determine which type of event was returned by `session.NextEvent()`. Currently it only returns the underlying message. 

**Solution**: Return the event name with the message (as sent from the server). This allows us to easily switch-case on the returned event name.

---

This was just a quick diff I threw together to have a working proof of concept for discussion. The actual interface can be different, since this of course breaks the current API. 

I suppose if you wanted strict backwards compatibility you could have a `session.NextEventWithName()` and just have a third return value, but switching to a struct now will allow us to add new fields later without breaking the API.

I'll leave the design decision up to you :)