### PR TITLE
events: re-work events API into Subscribe/Unsubscribe event model

### DIFF
--- a/vici/events.go
+++ b/vici/events.go
@@ -176,8 +176,16 @@ func (el *eventListener) listen(events []string) (err error) {
 	return nil
 }
 
-func (el *eventListener) nextEvent() (Event, error) {
-	e := <-el.ec
+func (el *eventListener) nextEvent(ctx context.Context) (Event, error) {
+	var e Event
+
+	select {
+	case <-ctx.Done():
+		return Event{}, ctx.Err()
+	case e = <-el.ec:
+		// Event received, carry on.
+	}
+
 	if e.Message == nil && e.err == nil {
 		return Event{}, errChannelClosed
 	}

--- a/vici/session.go
+++ b/vici/session.go
@@ -27,7 +27,6 @@
 package vici
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -207,18 +206,18 @@ func (s *Session) StreamedCommandRequest(cmd string, event string, msg *Message)
 // event channel is closed, or the given context is cancelled. To receive events that
 // are registered here, use NextEvent. An error is returned if Listen is called while
 // Session already has an event listener registered.
-func (s *Session) Listen(ctx context.Context, events ...string) error {
+func (s *Session) Listen(events ...string) error {
 	s.emux.Lock()
 	defer s.emux.Unlock()
 
-	if err := s.maybeCreateEventListener(ctx); err != nil {
+	if err := s.maybeCreateEventListener(); err != nil {
 		return err
 	}
 
 	return s.el.listen(events)
 }
 
-func (s *Session) maybeCreateEventListener(ctx context.Context) error {
+func (s *Session) maybeCreateEventListener() error {
 	if s.el != nil {
 		if s.el.isActive() {
 			return errEventListenerExists
@@ -231,7 +230,7 @@ func (s *Session) maybeCreateEventListener(ctx context.Context) error {
 		return err
 	}
 
-	s.el = newEventListener(ctx, elt)
+	s.el = newEventListener(elt)
 
 	return nil
 }

--- a/vici/session.go
+++ b/vici/session.go
@@ -27,6 +27,7 @@
 package vici
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -238,7 +239,7 @@ func (s *Session) maybeCreateEventListener() error {
 // NextEvent returns the next event received by the session event listener.  NextEvent is a
 // blocking call. If there is no event in the event buffer, NextEvent will wait to return until
 // a new event is received. An error is returned if the event channel is closed.
-func (s *Session) NextEvent() (Event, error) {
+func (s *Session) NextEvent(ctx context.Context) (Event, error) {
 	s.emux.RLock()
 	defer s.emux.RUnlock()
 
@@ -246,5 +247,5 @@ func (s *Session) NextEvent() (Event, error) {
 		return Event{}, errNoEventListener
 	}
 
-	return s.el.nextEvent()
+	return s.el.nextEvent(ctx)
 }

--- a/vici/session.go
+++ b/vici/session.go
@@ -201,6 +201,26 @@ func (s *Session) Subscribe(events ...string) error {
 	return s.el.registerEvents(events)
 }
 
+// Unsubscribe unregisters the given events, so the session will no longer
+// receive events of the given type. If a given event is not valid, or the
+// session is not currently subscribed to a given event, there is no error
+// and nothing happens.
+func (s *Session) Unsubscribe(events ...string) {
+	s.emux.Lock()
+	defer s.emux.Unlock()
+
+	s.el.unregisterEvents(events)
+}
+
+// UnsubscribeAll unregisters all events that the session is currently
+// subscribed to.
+func (s *Session) UnsubscribeAll() {
+	s.emux.Lock()
+	defer s.emux.Unlock()
+
+	s.el.unregisterEvents(s.el.events)
+}
+
 // NextEvent returns the next event received by the session event listener.  NextEvent is a
 // blocking call. If there is no event in the event buffer, NextEvent will wait to return until
 // a new event is received. An error is returned if the event channel is closed.

--- a/vici/session.go
+++ b/vici/session.go
@@ -239,12 +239,12 @@ func (s *Session) maybeCreateEventListener(ctx context.Context) error {
 // NextEvent returns the next event received by the session event listener.  NextEvent is a
 // blocking call. If there is no event in the event buffer, NextEvent will wait to return until
 // a new event is received. An error is returned if the event channel is closed.
-func (s *Session) NextEvent() (*Message, error) {
+func (s *Session) NextEvent() (Event, error) {
 	s.emux.RLock()
 	defer s.emux.RUnlock()
 
 	if s.el == nil {
-		return nil, errNoEventListener
+		return Event{}, errNoEventListener
 	}
 
 	return s.el.nextEvent()

--- a/vici/session.go
+++ b/vici/session.go
@@ -206,9 +206,8 @@ func (s *Session) UnsubscribeAll() error {
 	return s.el.unregisterEvents(nil, true)
 }
 
-// NextEvent returns the next event received by the session event listener.  NextEvent is a
-// blocking call. If there is no event in the event buffer, NextEvent will wait to return until
-// a new event is received. An error is returned if the event channel is closed.
+// NextEvent returns the next event received by the session event listener.  NextEvent will block
+// until an Event (or error) is received, or until the supplied context is closed.
 func (s *Session) NextEvent(ctx context.Context) (Event, error) {
 	return s.el.nextEvent(ctx)
 }


### PR DESCRIPTION
Closes: https://github.com/strongswan/govici/issues/19

Provide a more usable API for event listening with `Session.Subscribe`, `Session.Unsubscribe`, and `Session.UnsubscribeAll`. Unlike before, the event listener is active as long as the `Session` itself is, and registered events can be added/removed at anytime. `Session.NextEvent` now accepts a `context.Context` if additional control is needed.

These are obviously API-breaking changes, but this is acceptable pre-v1.0.0 and will ultimately help API stability be achieved. 