### PR TITLE
events: correctly handle io.EOF in listen()

### DIFF
--- a/vici/transport.go
+++ b/vici/transport.go
@@ -25,6 +25,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 )
 
@@ -80,9 +81,14 @@ func (t *transport) recv() (*packet, error) {
 
 	_, err := t.conn.Read(buf)
 	if err != nil {
+		if err == io.EOF {
+			return nil, err
+		}
+
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
 			return nil, ne
 		}
+
 		return nil, fmt.Errorf("%v: %v", errTransport, err)
 	}
 	pl := binary.BigEndian.Uint32(buf)
@@ -90,6 +96,14 @@ func (t *transport) recv() (*packet, error) {
 	buf = make([]byte, int(pl))
 	_, err = t.conn.Read(buf)
 	if err != nil {
+		if err == io.EOF {
+			return nil, err
+		}
+
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return nil, ne
+		}
+
 		return nil, fmt.Errorf("%v: %v", errTransport, err)
 	}
 


### PR DESCRIPTION
When an event is registered, and the event listener's transport closes
for some reason (e.g. charon is stopped) Session.Close() will never
return because the listen() loop will fill up the event channel with EOF
errors, and block indefinitely on a channel write (therefore never
checking if the event listener context is Done() again).

When the event listener receives io.EOF, it should return. Doing this
fixes the potential deadlock issue and allows Session.Close() to return
in such a case.

Add a regression test to verify this fix.

Fixes: https://github.com/strongswan/govici/issues/24

Signed-off-by: Nick Rosbrook <nr@enr0n.net>