### PR TITLE
message: support for marshalling embedded structs

### DIFF
--- a/vici/message_marshal_test.go
+++ b/vici/message_marshal_test.go
@@ -253,3 +253,33 @@ func TestMarshalEmbeddedMap(t *testing.T) {
 		t.Fatalf("Marshalled map value is invalid.\nExpected: %+v\nReceived: %+v", goldMarshaled, value)
 	}
 }
+
+func TestMarshalEmbeddedStruct(t *testing.T) {
+	const testValue = "marshalled-embedded-value"
+
+	type Embedded struct {
+		Field string `vici:"field"`
+	}
+
+	embeddedMessage := struct {
+		Embedded `vici:"embedded"`
+	}{}
+
+	embeddedMessage.Field = testValue
+
+	m, err := MarshalMessage(embeddedMessage)
+	if err != nil {
+		t.Fatalf("Errorf marshalling embedded struct: %v", err)
+	}
+
+	value := m.Get("embedded")
+	embedded, ok := value.(*Message)
+	if !ok {
+		t.Fatalf("Embedded struct was not marshalled as a sub-message")
+	}
+
+	value = embedded.Get("field")
+	if !reflect.DeepEqual(value, testValue) {
+		t.Fatalf("Marshalled embedded struct value is invalid.\nExpected: %+v\nReceived: %+v", testValue, value)
+	}
+}

--- a/vici/message_marshal_test.go
+++ b/vici/message_marshal_test.go
@@ -25,6 +25,74 @@ import (
 	"testing"
 )
 
+func TestMarshalTagSkip(t *testing.T) {
+	skipMessage := struct {
+		Skipped string `vici:""`
+	}{
+		Skipped: "skipped",
+	}
+
+	m, err := MarshalMessage(skipMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling skipped value: %v", err)
+	}
+
+	if len(m.Keys()) != 0 {
+		t.Fatalf("Marshalled message has keys.\nExpected: 0\nReceived: %d", len(m.Keys()))
+	}
+}
+
+func TestMarshalTagSkipDash(t *testing.T) {
+	skipMessage := struct {
+		Skipped string `vici:"-"`
+	}{
+		Skipped: "skipped",
+	}
+
+	m, err := MarshalMessage(skipMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling skipped value: %v", err)
+	}
+
+	if len(m.Keys()) != 0 {
+		t.Fatalf("Marshalled message has keys.\nExpected: 0\nReceived: %d", len(m.Keys()))
+	}
+}
+
+func TestMarshalTagSkipWithOpt(t *testing.T) {
+	skipMessage := struct {
+		Skipped string `vici:",testOpt"`
+	}{
+		Skipped: "skipped",
+	}
+
+	m, err := MarshalMessage(skipMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling skipped value: %v", err)
+	}
+
+	if len(m.Keys()) != 0 {
+		t.Fatalf("Marshalled message has keys.\nExpected: 0\nReceived: %d", len(m.Keys()))
+	}
+}
+
+func TestMarshalTagSkipDashWithOpt(t *testing.T) {
+	skipMessage := struct {
+		Skipped string `vici:"-,testOpt"`
+	}{
+		Skipped: "skipped",
+	}
+
+	m, err := MarshalMessage(skipMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling skipped value: %v", err)
+	}
+
+	if len(m.Keys()) != 0 {
+		t.Fatalf("Marshalled message has keys.\nExpected: 0\nReceived: %d", len(m.Keys()))
+	}
+}
+
 func TestMarshalBoolTrue(t *testing.T) {
 	boolMessage := struct {
 		Field bool `vici:"field"`
@@ -281,5 +349,74 @@ func TestMarshalEmbeddedStruct(t *testing.T) {
 	value = embedded.Get("field")
 	if !reflect.DeepEqual(value, testValue) {
 		t.Fatalf("Marshalled embedded struct value is invalid.\nExpected: %+v\nReceived: %+v", testValue, value)
+	}
+}
+
+func TestMarshalInline(t *testing.T) {
+	testValue := "marshal-inline"
+
+	type Embedded struct {
+		Field string `vici:"field"`
+	}
+
+	inlineMessage := struct {
+		Embedded `vici:",inline"`
+	}{}
+
+	inlineMessage.Field = testValue
+
+	m, err := MarshalMessage(inlineMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling inlined embedded struct: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, testValue) {
+		t.Fatalf("Marshalled inlined embedded value is invalid.\nExpected: %+v\nReceived: %+v", testValue, value)
+	}
+}
+
+func TestMarshalInlineInvalidType(t *testing.T) {
+	inlineMessage := struct {
+		Field string `vici:",inline"`
+	}{}
+
+	inlineMessage.Field = "inline-value"
+
+	_, err := MarshalMessage(inlineMessage)
+	if err == nil {
+		t.Error("Expected error when marshalling invalid inlined embedded type. None was returned.")
+	}
+}
+
+func TestMarshalInlineComposite(t *testing.T) {
+	testValue := "marshal-inline-composite"
+	otherValue := "other-value"
+
+	type Embedded struct {
+		Field string `vici:"field"`
+	}
+
+	inlineMessage := struct {
+		Embedded `vici:",inline"`
+		Other    string `vici:"other"`
+	}{}
+
+	inlineMessage.Field = testValue
+	inlineMessage.Other = otherValue
+
+	m, err := MarshalMessage(inlineMessage)
+	if err != nil {
+		t.Fatalf("Error marshalling inlined embedded struct: %v", err)
+	}
+
+	value := m.Get("field")
+	if !reflect.DeepEqual(value, testValue) {
+		t.Fatalf("Marshalled inlined embedded value is invalid.\nExpected: %+v\nReceived: %+v", testValue, value)
+	}
+
+	value = m.Get("other")
+	if !reflect.DeepEqual(value, otherValue) {
+		t.Fatalf("Marshalled inlined embedded value is invalid.\nExpected: %+v\nReceived: %+v", otherValue, value)
 	}
 }

--- a/vici/message_unmarshal_test.go
+++ b/vici/message_unmarshal_test.go
@@ -312,3 +312,36 @@ func TestUnmarshalEnumType(t *testing.T) {
 		t.Fatalf("Unmarshalled uint value is invalid.\nExpected: %+v\nReceived: %+v", testValue, enumMessage.Field)
 	}
 }
+
+func TestUnmarshalEmbeddedStruct(t *testing.T) {
+	const testValue = "unmarshalled-embedded-value"
+
+	type Embedded struct {
+		Field string `vici:"field"`
+	}
+
+	embeddedMessage := struct {
+		Embedded `vici:"embedded"`
+	}{}
+
+	m := &Message{
+		[]string{"embedded"},
+		map[string]interface{}{
+			"embedded": &Message{
+				[]string{"field"},
+				map[string]interface{}{
+					"field": testValue,
+				},
+			},
+		},
+	}
+
+	err := UnmarshalMessage(m, &embeddedMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling into embedded struct: %v", err)
+	}
+
+	if embeddedMessage.Field != testValue {
+		t.Fatalf("Unmarshalled embedded value is invalid.\nExpected: %+v\nReceived: %+v", testValue, embeddedMessage.Field)
+	}
+}

--- a/vici/message_unmarshal_test.go
+++ b/vici/message_unmarshal_test.go
@@ -345,3 +345,84 @@ func TestUnmarshalEmbeddedStruct(t *testing.T) {
 		t.Fatalf("Unmarshalled embedded value is invalid.\nExpected: %+v\nReceived: %+v", testValue, embeddedMessage.Field)
 	}
 }
+
+func TestUnmarshalInline(t *testing.T) {
+	testValue := "unmarshal-inline"
+
+	type Embedded struct {
+		Field string `vici:"field"`
+	}
+
+	inlineMessage := struct {
+		Embedded `vici:",inline"`
+	}{}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": testValue,
+		},
+	}
+
+	err := UnmarshalMessage(m, &inlineMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling into inlined embedded struct: %v", err)
+	}
+
+	if inlineMessage.Field != testValue {
+		t.Fatalf("Unmarshalled inlined embedded value is invalid.\nExpected: %+v\nReceived: %+v", testValue, inlineMessage.Field)
+	}
+}
+
+func TestUnmarshalInlineInvalidType(t *testing.T) {
+	inlineMessage := struct {
+		Field string `vici:",inline"`
+	}{}
+
+	m := &Message{
+		[]string{"field"},
+		map[string]interface{}{
+			"field": "test-value",
+		},
+	}
+
+	err := UnmarshalMessage(m, &inlineMessage)
+	if err == nil {
+		t.Error("Expected error when unmarshalling invalid inlined embedded type. None was returned.")
+	}
+}
+
+func TestUnmarshalInlineComposite(t *testing.T) {
+	testValue := "unmarshal-inline-composite"
+	otherValue := "other-value"
+
+	type Embedded struct {
+		Field string `vici:"field"`
+	}
+
+	inlineMessage := struct {
+		Embedded `vici:",inline"`
+		Other    string `vici:"other"`
+	}{}
+
+	m := &Message{
+		[]string{"field", "other"},
+		map[string]interface{}{
+			"field": testValue,
+			"other": otherValue,
+		},
+	}
+
+	err := UnmarshalMessage(m, &inlineMessage)
+	if err != nil {
+		t.Fatalf("Error unmarshalling into inlined embedded struct: %v", err)
+	}
+
+	if inlineMessage.Field != testValue {
+		t.Fatalf("Unmarshalled inlined embedded value is invalid.\nExpected: %+v\nReceived: %+v", testValue, inlineMessage.Field)
+	}
+
+	if inlineMessage.Other != otherValue {
+		t.Fatalf("Unmarshalled inlined embedded value is invalid.\nExpected: %+v\nReceived: %+v", otherValue, inlineMessage.Other)
+	}
+}


### PR DESCRIPTION
Add support for marshalling (and unmarshalling) with embedded structs.
Embedded structs can use the new "inline" struct tag opt to signal that they
should be treated as inlined values.

```go
  type Embedded struct {
      Field string `vici:"field"`
  }

  type MyMessage struct {
      Embedded  `vici:",inline"`
      Other     string `vici:"other"`
  }
```

This allows using a common embedded struct for different message types which
share common fields.

Includes tests for both the tag parsing function (to ensure that skip still works as expected) and obviously for the inline marshal/unmarshal.

Let me know what you think!