### PR TITLE
build: add golangci-lint config file and enable specific linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,66 @@
+run:
+  timeout: 5m
+  allow-parallel-runners: true
+
+issues:
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+#  - asciicheck
+  - bodyclose
+  - deadcode
+  - depguard
+  - dogsled
+  - dupl
+  - errcheck
+#  - exhaustive
+#  - exportloopref
+#  - funlen
+#  - gci
+#  - gochecknoglobals
+#  - gochecknoinits
+#  - gocognit
+  - goconst
+  - gocritic
+  - gocyclo
+#  - godot
+  - godox
+#  - goerr113
+  - gofmt
+#  - gofumpt
+#  - goheader
+  - goimports
+  - golint
+#  - gomnd
+#  - gomodguard
+  - goprintffuncname
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - interfacer
+#  - lll
+  - maligned
+  - misspell
+  - nakedret
+#  - nestif
+#  - nlreturn
+#  - noctx
+#  - nolintlint
+  - prealloc
+  - rowserrcheck
+  - scopelint
+#  - sqlclosecheck
+  - staticcheck
+  - structcheck
+  - stylecheck
+#  - testpackage
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
+  - varcheck
+  - whitespace
+#  - wsl

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test:
 
 .PHONY: golint
 golint:
-	golangci-lint --verbose run --enable-all -Dgochecknoglobals -Dgochecknoinits -Dlll -Dgomnd -Dfunlen -Dwsl -Dgocognit
+	golangci-lint --verbose run


### PR DESCRIPTION
Rather than enabling all linters and disabling unwanted ones, by only enabling the desired ones, it makes results compatible with more up-to-date versions of golangci-lint. Otherwise, when new linters are added, they will run and can cause the linters to fail.

---

Of course this is completely up to you. This still runs the same 34 linters that are running in travis. My issue is I am running version 1.30.0 on my local machine, which was returning a bunch of failures since the newer linters were being run due to the `--enable-all`. 

I migrated to using a config file since it's easier to list all the linters and enable them rather than doing it through a bunch of flags.