### PR TITLE
fix bug of windows platform socket operation encountered a dead network

### DIFF
--- a/vici/session.go
+++ b/vici/session.go
@@ -22,7 +22,9 @@ package vici
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"runtime"
 	"sync"
 )
 
@@ -45,12 +47,24 @@ type Session struct {
 
 // NewSession returns a new vici session.
 func NewSession(opts ...SessionOption) (*Session, error) {
+
+	var socketPath string
+	var network string
+	fmt.Println("os type: " + runtime.GOOS)
+	if runtime.GOOS == "windows" {
+		network = "tcp"
+		socketPath = windowsdefaultSocketPath
+	} else {
+		network = "unix"
+		socketPath = defaultSocketPath
+	}
+
 	s := &Session{
 		// Set default session opts before applying
 		// the opts passed by the caller.
 		sessionOpts: &sessionOpts{
-			network: "unix",
-			addr:    defaultSocketPath,
+			network: network,
+			addr:    socketPath,
 			dialer:  (&net.Dialer{}).DialContext,
 			conn:    nil,
 		},

--- a/vici/transport.go
+++ b/vici/transport.go
@@ -29,7 +29,8 @@ import (
 
 const (
 	// Default unix socket path
-	defaultSocketPath = "/var/run/charon.vici"
+	defaultSocketPath        = "/var/run/charon.vici"
+	windowsdefaultSocketPath = "127.0.0.1:4502"
 
 	// Each segment is prefixed by a 4-byte header in network oreder
 	headerLength = 4


### PR DESCRIPTION
On windows platform, new session failed with error:
``` bash
unix /var/run/charon.vici: connect: A socket operation encountered a dead network.
vici new session failed: dial unix /var/run/charon.vici: connect: A socket operation encountered a dead network.
```
