### PR TITLE
Fix: remove SetReadDeadline in wait() to prevent undesirable exit on listen()

### DIFF
--- a/vici/client_conn.go
+++ b/vici/client_conn.go
@@ -215,22 +215,8 @@ func (cc *clientConn) wait(ctx context.Context) (*Message, error) {
 		return nil, errors.New("context cannot be nil")
 	}
 
-	// nolint
-	defer cc.conn.SetReadDeadline(time.Time{})
 	for {
-		// Wait for the response packet as long as the context is not
-		// cancelled, and as long as we continue receiving packets from
-		// the server.
-		deadline := time.Now().Add(5 * time.Second)
-
-		if d, ok := ctx.Deadline(); ok && d.After(deadline) {
-			deadline = d.Add(5 * time.Second)
-		}
-
-		if err := cc.conn.SetReadDeadline(deadline); err != nil {
-			return nil, err
-		}
-
+		// Timeout should be handled by caller's context
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/vici/client_conn_test.go
+++ b/vici/client_conn_test.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"io"
 	"net"
-	"os"
 	"reflect"
 	"strconv"
 	"sync"
@@ -536,18 +535,6 @@ func TestClientConnWaitNoResponse(t *testing.T) {
 		synctest.Wait()
 		if _, err := cc.wait(ctx); !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("Expected deadline exceeded on wait, but got %v", err)
-		}
-
-		// Without a context deadline, we should get a timeout error from
-		// the default read deadline.
-		in.header.name = "cmd-no-response"
-		if err := cc.write(context.Background(), in); err != nil {
-			t.Fatalf("Failed to write %s: %v", in.header.name, err)
-		}
-
-		synctest.Wait()
-		if _, err := cc.wait(context.Background()); !errors.Is(err, os.ErrDeadlineExceeded) {
-			t.Fatalf("Expected timeout on wait, but got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Currently, listener is not persistent as it returns immediately after whatever error occurs.
If a caller, wait() to name one, sets read deadline and then times out, it means subsequently this listener also exits while there is no reason to do so.
This behavior might indirectly cost consumers of events as they have to make a preventable re-connection after a single timeout error. 